### PR TITLE
fix: 可偵測國際板MuMu模擬器

### DIFF
--- a/kotonebot/client/host/mumu12_host.py
+++ b/kotonebot/client/host/mumu12_host.py
@@ -53,8 +53,6 @@ class Mumu12Host(HostProtocol[MuMu12Recipes]):
 
         uninstall_subkeys = [
             r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer-12.0',
-            # TODO: 支持国际版 MuMu
-            # r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal-12.0'
         ]
 
         for subkey in uninstall_subkeys:
@@ -290,8 +288,8 @@ class Mumu12V5Host(Mumu12Host):
 
         uninstall_subkeys = [
             r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer',
+            r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal',
         ]
-
         for subkey in uninstall_subkeys:
             icon_path = read_reg('HKLM', subkey, 'DisplayIcon', default=None)
             if icon_path and isinstance(icon_path, str):


### PR DESCRIPTION
## 問題描述

使用 MuMu Player Global（國際版）的用戶，`Mumu12V5Host` 無法偵測到安裝路徑，
導致回報找不到模擬器。

## 原因

MuMu Player Global 的 Uninstall registry key 為 `MuMuPlayerGlobal`，
原本的偵測只查 `MuMuPlayer`（中國版），因此漏掉國際版。

## 修改內容

在 `Mumu12V5Host._read_install_path()` 的 `uninstall_subkeys` 加入 Global 的 key：

```python
uninstall_subkeys = [
    r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer',
    r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal',  # Global edition
]
```
MuMu Player Global 的 DisplayIcon 同樣指向 nx_main\...，
與現有的路徑拆解邏輯完全相容，不需要額外修改。

另外移除 Mumu12Host 中猜測的 TODO（MuMuPlayerGlobal-12.0），
實際上該 key 不存在，Global 版本使用 V5 架構，應由 Mumu12V5Host 處理。

## 驗證
Registry 截圖與測試輸出：

HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal 存在
DisplayIcon = C:\Program Files\Netease\MuMuPlayer\nx_main\MuMuNxMain.ico
偵測結果：C:\Program Files\Netease\MuMuPlayer（路徑存在 ）

<img width="1492" height="479" alt="image" src="https://github.com/user-attachments/assets/cbb8bf5c-177b-4b2f-a352-1445f97a926e" />
